### PR TITLE
Changing the master-slave words

### DIFF
--- a/RestOC/Record_MySQL.py
+++ b/RestOC/Record_MySQL.py
@@ -316,7 +316,7 @@ class Commands(object):
 		Args:
 			host (str): The name of the connection to escape for
 			value (str): The value to escape
-			rel (str): The relationship of the server, master or slave
+			rel (str): The relationship of the server, main or subordinate
 
 		Returns:
 			str


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.